### PR TITLE
feat: add barstool

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 
 - [2Do](https://www.2doapp.com/) - Powerful & flexible GTD task manager.
 - [Air Pasteboard](https://apps.apple.com/us/app/air-pasteboard/id1327733671?mt=12) - Quick pasteboard and file sharing.
+- [Barstool](https://barstool.lotl.dev) - The better menubar made for macOS.
 - [BetterTouchTool](https://www.boastr.net/)
 - [Fantastical](https://flexibits.com/fantastical)
 - [Keyboard Maestro](https://www.keyboardmaestro.com/main/) - Automation engine.


### PR DESCRIPTION
Add [Barstool](https://barstool.lotl.dev), a productivity app that sits next to your notch and lets you control your mac.

<img width="999" height="349" alt="hero" src="https://github.com/user-attachments/assets/744b4cc0-4e3d-4ee7-b6db-063d08cb59a4" />
