### PR TITLE
Add Lockpaw (resubmission of #40)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -179,6 +179,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Karabiner](https://pqrs.org/osx/karabiner/) - Powerful keyboard customizer.
 - [Keka](https://www.keka.io)
 - [Little Snitch](https://www.obdev.at/products/littlesnitch/index.html)
+- [Lockpaw](https://github.com/sorkila/lockpaw) - Menu bar screen guard that locks your screen with a hotkey without sleeping; builds and AI agents keep running with input blocked, and the screen glows when your agent needs you. Free and open source, with Touch ID unlock.
 - [Lumen](https://github.com/anishathalye/lumen)
 - [MonthlyCal](https://itunes.apple.com/us/app/monthlycal-colorful-monthly/id935250717?mt=12) - Notification Center Calendar
 - [Name mangler](https://manytricks.com/namemangler/)


### PR DESCRIPTION
This resubmits #40, which was auto-closed when I accidentally deleted the source fork during a cleanup — it was never reviewed or rejected, so apologies for the noise. Lockpaw is a menu bar screen guard for macOS: lock your screen with a hotkey without sleeping, so builds and AI agents keep running with input blocked, and the screen glows when your agent needs you. Free, MIT-licensed, native Swift, no telemetry. Website: https://getlockpaw.com — Source: https://github.com/sorkila/lockpaw

🤖 Generated with [Claude Code](https://claude.com/claude-code)