### PR TITLE
Add Persona & Clickyy — local-first workspace + screen-aware AI agent

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # macOS apps [![Lists](https://img.shields.io/badge/-more%20lists-0a0a0a.svg?style=flat&colorA=0a0a0a)](https://github.com/learn-anything/curated-lists)
 
+- [Persona](https://github.com/jayamitkatariya/personacli) - Local-first personal workspace: notes, tasks, and AI chat over plain Markdown files. Connects to Ollama for free private AI.
+- [Clickyy](https://github.com/jayamitkatariya/clickyyy) - Open-source macOS menu bar AI agent: shake cursor to summon an overlay that sees your screen and can click, type, and act.
 _Please read [contribution guidelines](contributing.md) before contributing._
 
 - [Audio](#audio)


### PR DESCRIPTION
Adding two open-source macOS apps:

- [Persona](https://github.com/jayamitkatariya/personacli) — local-first personal workspace: notes, tasks and AI chat as plain Markdown files. Free private AI via Ollama auto-detection. MIT.
- [Clickyy](https://github.com/jayamitkatariya/clickyyy) — menu bar AI agent: shake cursor to summon a screen-aware overlay that can click, type and act for you. MIT.