### PR TITLE
Add Screenpipe

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [MindNode](https://mindnode.com/) - Create interactive mind maps.
 - [Next meeting](https://itunes.apple.com/us/app/next-meeting-quickly-see-it-in-your-menu-bar/id1017470484?mt=12)
 - [PDF Archiver](https://github.com/JulianKahnert/PDF-Archiver) - Tag and archive documents.
+- [Screenpipe](https://screenpipe.com/) - Record screen and audio locally for searchable computer history and AI-assisted recall.
 - [Timing 2](https://betalist.com/startups/timing-2)
 - [TogglDesktop](https://support.toggl.com/toggl-on-my-desktop/)
 - [Trello](https://itunes.apple.com/app/trello/id1278508951?ls=1&mt=12)


### PR DESCRIPTION
Adds Screenpipe to Productivity as a macOS app for searchable, locally recorded computer history.

Disclosure: I maintain Screenpipe. The entry uses the existing list format and a factual one-line description. Thank you for considering it; I am happy to adjust or close the PR if it is not a fit.