### PR TITLE
Add Tidy to Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -187,6 +187,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Popclip](https://pilotmoon.com/popclip/)
 - [Spotifree](http://spotifree.gordinskiy.com/)
 - [Swish](https://highlyopinionated.co/swish/) - A gesture layer and window manager for the trackpad power user.
+- [Tidy](https://tidymacapp.com) - Renames files by reading their contents with on-device OCR, and sorts Downloads by rules.
 - [Typinator](http://www.ergonis.com/products/typinator/) - Text expansions.
 - [Unclutter](https://unclutterapp.com/)
 - [Mouse Jiggler for Mac](https://mousejigglermac.com) - Prevent Mac from sleep with Mac Mouse Mover.


### PR DESCRIPTION
Tidy is a menu bar app for macOS that renames incoming files by reading what is inside them: it runs the Mac's own OCR on PDFs, screenshots and scans, names the file after the text it finds, and files it by rule. Everything runs on device, with no account and no server. $9 one-time, macOS 14 or later.

Followed contributing.md: searched the list first, one entry in the closest category, description starts with a capital, ends with a full stop, and does not start with "A".