### PR TITLE
Add AskClean to Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 ## Utilities
 
 - [Alfred](https://www.alfredapp.com/) - Customizable launcher with [many powerful workflows](https://github.com/learn-anything/alfred-workflows#amazing-alfred-workflows-).
+- [AskClean](https://www.askclean.app/) - Explains disk storage items, asks for confirmation, and moves approved files to the Trash.
 - [Bartender](https://www.macbartender.com/) - Organize menu bar apps.
 - [Bearded spice](https://github.com/beardedspice/beardedspice)
 - [Bitbar](https://github.com/matryer/bitbar)


### PR DESCRIPTION
Adds AskClean to the Utilities section in alphabetical order. The description focuses on its user-visible safety workflow: explaining storage items, requiring confirmation, and moving approved files to the Trash.

Validation:

- Checked the project URL returns HTTP 200 after its locale redirect.
- Confirmed the entry appears once and follows the requested description format.
- Ran `git diff --check`.
