### PR TITLE
Add Focuh to Productivity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -126,6 +126,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Air Pasteboard](https://apps.apple.com/us/app/air-pasteboard/id1327733671?mt=12) - Quick pasteboard and file sharing.
 - [BetterTouchTool](https://www.boastr.net/)
 - [Fantastical](https://flexibits.com/fantastical)
+- [Focuh](https://www.focuh.com) - ADHD to-do list, week planner, focus timer, and website/app blocker.
 - [Keyboard Maestro](https://www.keyboardmaestro.com/main/) - Automation engine.
 - [Merlin Project](https://www.projectwizards.net/en/merlin-project) – Project Management on macOS & iOS.
 - [MindNode](https://mindnode.com/) - Create interactive mind maps.


### PR DESCRIPTION
## Why

Adds [Focuh](https://www.focuh.com) to Productivity — a free ADHD-friendly Mac to-do list with week planner, focus timer, and system-wide website/app blocking.

## Checklist

- [x] Searched for duplicates (none)
- [x] Format: `- [Name](link) - Description.`
- [x] Description starts with a capital, ends with a period, does not start with A/An
- [x] Alphabetical in Productivity (after Fantastical)
- [x] Link goes to the product site (not /live)

Submitter is the developer.