### PR TITLE
Add SnipperApp 3 to Dev tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [OpenPaw](https://github.com/daxaur/openpaw) - Personal assistant skills for Claude Code. Focus mode, task dashboard, smart home control, 39 skills. `npx pawmode`
 - [Paw](https://paw.cloud/)
 - [Platypus](https://github.com/sveinbjornt/Platypus) - Create Mac applications from command line scripts.
+- [SnipperApp 3](https://snipperapp.com) - Native code snippet manager with iCloud and GitHub Gist sync and an MCP server for AI assistants.
 - [SnippetsLab](https://www.renfei.org/snippets-lab/)
 - [Sublime Merge](https://www.sublimemerge.com/) - Git client from makers of Sublime Text.
 - [Tower](https://www.git-tower.com/mac/)


### PR DESCRIPTION

Adds SnipperApp 3 to Dev tools, alphabetically before SnippetsLab. Native macOS code snippet manager with iCloud and GitHub Gist sync and an MCP server for AI assistants. Free 7-day trial, then a one-time purchase. I'm the developer.