### PR TITLE
Add AllPet — desktop pet that watches AI coding agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 ## Dev tools
 
 - [AgentGrid](https://agentgrid.sh) - Infinite zoomable canvas for orchestrating multiple AI coding agents in parallel, with role-based workers, per-agent git worktrees, and integrated terminals and browser panes.
+- [AllPet](https://github.com/haverainlilili/all-pet) - Desktop pet that watches your AI coding agents (Codex, Claude Code, DeepSeek Harness, Grok) and wakes tasks.
 - [Bee](https://www.neat.io/bee/) - Issue tracker.
 - [Command Book](https://commandbookapp.com) - A terminal companion for long-running terminal commands.
 - [Dash](https://kapeli.com/dash)


### PR DESCRIPTION
## What

Add [AllPet](https://github.com/haverainlilili/all-pet) to **Dev tools** — a free MIT desktop pet that watches your AI coding agents (Codex, Claude Code / Desktop, DeepSeek Harness, and Grok) from their local session logs (no accounts/API keys), switches animation by live task state, and wakes the original session on click.

## Checklist

- [x] Searched existing entries — no duplicate.
- [x] Follows the `[Name](link) - Description.` format.
- [x] Description starts with a capital, ends with a full stop, no leading "A"/"An".