### PR TITLE
Add LiveFaceSwap Desktop to Video

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -195,6 +195,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 ## Video
 
 - [IINA](https://github.com/lhc70000/iina)
+- [LiveFaceSwap Desktop](https://livefaceswap.ai/desktop) - Real-time face swapping with virtual-camera output for streaming and video calls on Apple Silicon Macs.
 - [MPV](https://mpv.io/)
 - [ScreenFlow](https://www.telestream.net/screenflow/overview.htm)
 - [Claquette](https://www.peakstep.com/claquette/) - Easy-to-use video utility.


### PR DESCRIPTION
Adds [LiveFaceSwap Desktop](https://livefaceswap.ai/desktop) to Video for Mac users who want to send an AI-transformed camera feed to streaming or calling software.

The public Mac download supports Apple Silicon with macOS 13 or later. Processing runs in the cloud and requires internet access; AI usage is credit-based, so this is not an offline or unlimited-free application.

Disclosure: this recommendation is submitted on behalf of the LiveFaceSwap product team. I checked the current download page, category placement, contribution format, and existing entries for duplicates.



