### PR TITLE
Add Lyrimuse to Music

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Spotify](https://www.spotify.com/)
 - [Tine Player](http://www.catnapgames.com/tiny-player-for-mac/)
 - [LyricsX](https://github.com/ddddxxx/LyricsX) - Ultimate lyrics app for macOS.
+- [Lyrimuse](https://github.com/Yudaotor/lyrimuse) - Word-synced desktop lyrics for Apple Music, Spotify, QQ Music, NetEase Cloud Music and browser web players, picked by scoring every candidate.
 
 ## Productivity
 


### PR DESCRIPTION
Adds [Lyrimuse](https://github.com/Yudaotor/lyrimuse) to the Music section, next to LyricsX.

Free and open source (GPL-3.0) desktop lyrics for macOS. Word-by-word synced, and it reads playback from Apple Music, Spotify, QQ Music, NetEase Cloud Music and Kugou, plus YouTube Music or Spotify Web in a browser. Instead of taking the first provider that answers, it scores every candidate from nine sources on one scale so live takes and radio edits get the lyrics that actually match.

Disclosure: I'm the author.

Checked against contributing.md: searched the list for duplicates first, used the `- [Name](link) - Description.` format, put it in the closest existing category, description starts with a capital, ends with a full stop and does not start with A/An.